### PR TITLE
Fix following words

### DIFF
--- a/_sources/command_reference.txt
+++ b/_sources/command_reference.txt
@@ -60,7 +60,7 @@ Options:
   Example: --rerun
 
 :command:`-s, --start +NAME`
-  If this option is set, Digdag runs this task and following tasks even if the tasks successfully finished before. The other tasks will be skipped if their state files are stored at ``-o, --save`` directory.
+  If this option is set, Digdag runs this task and the following tasks even if the tasks successfully finished before. The other tasks will be skipped if their state files are stored at ``-o, --save`` directory.
 
   Example: --start +step2
 
@@ -70,7 +70,7 @@ Options:
   Example: --goal +step2
 
 :command:`-e, --end +NAME`
-  Stops workflow right before this task. This task and following tasks will be skipped.
+  Stops workflow right before this task. This task and the following tasks will be skipped.
 
   Example: --end +step4
 
@@ -292,7 +292,7 @@ Runs a digdag server. --memory or --database option is required. Examples:
   Example: -c digdag.properties
 
 
-In the config file, following parameters are available
+In the config file, the following parameters are available
 
 * server.bind (ip address)
 * server.port (integer)
@@ -332,7 +332,7 @@ Client-mode common options:
 
   Example: -c digdag-server/client.properties
 
-You can include following parameters in ~/.config/digdag/config file:
+You can include the following parameters in ~/.config/digdag/config file:
 
 * cilent.http.endpoint = http://HOST:PORT or https://HOST:PORT
 * client.http.headers.KEY = VALUE (set custom HTTP header)
@@ -416,7 +416,7 @@ Examples:
   Retry only failed tasks. Successfully finished tasks are skipped.
 
 :command:`--resume-from +NAME`
-  Retry from this task. This task and all following tasks will be executed. All tasks before this task must have been successfully finished.
+  Retry from this task. This task and all of the following tasks will be executed. All tasks before this task must have been successfully finished.
 
 :command:`--name <name>`
   An unique identifier of this retry attempt. If another attempt with the same name already exists within the same session, request fails with 409 Conflict.

--- a/_sources/getting_started.txt
+++ b/_sources/getting_started.txt
@@ -2,7 +2,7 @@
 
 ## 1. Downloading the latest version
 
-Digdag is a simple executable file. You can download the file to ``/usr/local/bin`` using `curl` command as following:
+Digdag is a simple executable file. You can download the file to ``/usr/local/bin`` using `curl` command as follows:
 
     $ curl -o /usr/local/bin/digdag --create-dirs -L "https://dl.digdag.io/digdag-latest"
     $ chmod +x /usr/local/bin/digdag

--- a/_sources/scheduling_workflow.txt
+++ b/_sources/scheduling_workflow.txt
@@ -20,7 +20,7 @@ To run a workflow periodically, add a ``schedule:`` option to top-level workflow
     +step1:
       sh>: tasks/shell_sample.sh
 
-In ``schedule:`` directive, you can choose one of following options:
+In ``schedule:`` directive, you can choose one of the following options:
 
 =============================== =========================================== ==========================
 Syntax                          Description                                 Example

--- a/_sources/workflow_definition.txt
+++ b/_sources/workflow_definition.txt
@@ -64,7 +64,7 @@ Name                            Description                                 Exam
 **session_unixtime**            Seconds since the epoch time                1454140800
 =============================== =========================================== ==========================
 
-If `schedule: option is set <scheduling_workflow.html>`_, **last_session_time** and **next_session_time** are also available as following:
+If `schedule: option is set <scheduling_workflow.html>`_, **last_session_time** and **next_session_time** are also available as follows:
 
 ==================================== ========================== ==========================
 Name                                 Example (hourly schedule)  Example (daily schedule)


### PR DESCRIPTION
Replace `as following` with `as follows`.
Replace `following` with `the following`.
See: ["following" と "as follows" の使い方](http://www.midorico.co.jp/tip/201206.html)

Both `all the following tasks` and `all of the following tasks` are correct.
See: http://forum.wordreference.com/threads/all-the-following-or-all-of-the-following.2306656/
