### PR TITLE
Fixed typo: cilent -> client

### DIFF
--- a/_sources/command_reference.txt
+++ b/_sources/command_reference.txt
@@ -334,7 +334,7 @@ Client-mode common options:
 
 You can include following parameters in ~/.config/digdag/config file:
 
-* cilent.http.endpoint = http://HOST:PORT or https://HOST:PORT
+* client.http.endpoint = http://HOST:PORT or https://HOST:PORT
 * client.http.headers.KEY = VALUE (set custom HTTP header)
 
 

--- a/command_reference.html
+++ b/command_reference.html
@@ -478,7 +478,7 @@
 </dl>
 <p>You can include following parameters in ~/.config/digdag/config file:</p>
 <ul class="simple">
-<li>cilent.http.endpoint = <a class="reference external" href="http://HOST:PORT">http://HOST:PORT</a> or <a class="reference external" href="https://HOST:PORT">https://HOST:PORT</a></li>
+<li>client.http.endpoint = <a class="reference external" href="http://HOST:PORT">http://HOST:PORT</a> or <a class="reference external" href="https://HOST:PORT">https://HOST:PORT</a></li>
 <li>client.http.headers.KEY = VALUE (set custom HTTP header)</li>
 </ul>
 <div class="section" id="start">


### PR DESCRIPTION
Typo on sample configuration kills user's time...
Please check & merge it.

cilent -> client
