### PR TITLE
fix typo for ruby operator

### DIFF
--- a/_sources/operators.txt
+++ b/_sources/operators.txt
@@ -83,7 +83,7 @@ See `Ruby API documents <ruby_api.html>`_ for details including best practices h
 .. code-block:: yaml
 
     _export:
-      ruby:
+      rb:
         require: tasks/my_workflow
 
     +step1:


### PR DESCRIPTION
it should be `rb` on using `_export:` and `require`. because it won't work with `ruby`.
cf. https://github.com/treasure-data/digdag-docs/blob/gh-pages/_sources/.txt#L11
