### PR TITLE
"password_override" option in redshift operator.

### DIFF
--- a/_sources/operators/redshift.md.txt
+++ b/_sources/operators/redshift.md.txt
@@ -223,9 +223,9 @@ When you set those parameters, use [digdag secrets command](https://docs.digdag.
 
 * **password_override**: NAME
 
-  Secret key name that has a non-default database password as its value. This would be useful whey you want to use multiple database credentials. If it's set, Digdag looks up secrets with this value as a secret key name. If not, the default secret key `redshift.password` is used.
+  Secret key name that has a non-default database password as its value. This would be useful whey you want to use multiple database credentials. If it's set, Digdag looks up secrets with this value as a secret key name. If not, the default secret key `aws.redshift.password` is used.
 
-  Examples (let's say you've already added a secret key value `redshift.another_password=password1234`):
+  Examples (let's say you've already added a secret key value `aws.redshift.another_password=password1234`):
 
   ```
   password_override: another_password


### PR DESCRIPTION
I' sorry for opened a same content issue in [#1328](https://github.com/treasure-data/digdag/issues/1328)

---

I found an issue in document, `password_override` option of `redshift` operator.

[redshift>: Redshift operations](http://docs.digdag.io/operators/redshift.html#options)

- Name of the secret key used by default

-> `aws.redshift.password`, not `redshift.password`

- Description of how to specify `password_override` value in option document

-> In case below, 

```
password_override: another_password
```

it will be used `aws.redshift.another_password` secret key actually. (I checked this in v0.9.40)
In document, it is written as `redshift.another_password`.