### PR TITLE
add status_table_cleanup option

### DIFF
--- a/operators/redshift.html
+++ b/operators/redshift.html
@@ -5,68 +5,68 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta charset="utf-8">
-  
+
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  
+
   <title>redshift&gt;: Redshift operations &mdash; Digdag 0.10.0 documentation</title>
-  
 
-  
-  
-  
-  
 
-  
+
+
+
+
+
+
   <script type="text/javascript" src="../_static/js/modernizr.min.js"></script>
-  
-    
+
+
       <script type="text/javascript" id="documentation_options" data-url_root="../" src="../_static/documentation_options.js"></script>
         <script type="text/javascript" src="../_static/jquery.js"></script>
         <script type="text/javascript" src="../_static/underscore.js"></script>
         <script type="text/javascript" src="../_static/doctools.js"></script>
         <script type="text/javascript" src="../_static/language_data.js"></script>
-    
+
     <script type="text/javascript" src="../_static/js/theme.js"></script>
 
-    
 
-  
+
+
   <link rel="stylesheet" href="../_static/css/theme.css" type="text/css" />
   <link rel="stylesheet" href="../_static/pygments.css" type="text/css" />
     <link rel="stylesheet" href="../_static/custom.css" type="text/css" />
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
     <link rel="next" title="redshift_load&gt;: Redshift load operations" href="redshift_load.html" />
-    <link rel="prev" title="s3_wait&gt;: Wait for a file in Amazon S3" href="s3_wait.html" /> 
+    <link rel="prev" title="s3_wait&gt;: Wait for a file in Amazon S3" href="s3_wait.html" />
 </head>
 
 <body class="wy-body-for-nav">
 
-   
+
   <div class="wy-grid-for-nav">
-    
+
     <nav data-toggle="wy-nav-shift" class="wy-nav-side">
       <div class="wy-side-scroll">
         <div class="wy-side-nav-search" >
-          
 
-          
+
+
             <a href="../index.html" class="icon icon-home"> Digdag
-          
 
-          
+
+
           </a>
 
-          
-            
-            
+
+
+
               <div class="version">
                 0.10
               </div>
-            
-          
 
-          
+
+
+
 <div role="search">
   <form id="rtd-search-form" class="wy-form" action="../search.html" method="get">
     <input type="text" name="q" placeholder="Search docs" />
@@ -75,16 +75,16 @@
   </form>
 </div>
 
-          
+
         </div>
 
         <div class="wy-menu wy-menu-vertical" data-spy="affix" role="navigation" aria-label="main navigation">
-          
-            
-            
-              
-            
-            
+
+
+
+
+
+
               <ul class="current">
 <li class="toctree-l1"><a class="reference internal" href="../getting_started.html">Getting started</a></li>
 <li class="toctree-l1"><a class="reference internal" href="../architecture.html">Architecture</a></li>
@@ -125,28 +125,28 @@
 <li class="toctree-l1"><a class="reference internal" href="../logo.html">Logo</a></li>
 </ul>
 
-            
-          
+
+
         </div>
       </div>
     </nav>
 
     <section data-toggle="wy-nav-shift" class="wy-nav-content-wrap">
 
-      
+
       <nav class="wy-nav-top" aria-label="top navigation">
-        
+
           <i data-toggle="wy-nav-top" class="fa fa-bars"></i>
           <a href="../index.html">Digdag</a>
-        
+
       </nav>
 
 
       <div class="wy-nav-content">
-        
+
         <div class="rst-content">
-        
-          
+
+
 
 
 
@@ -165,32 +165,32 @@
 <div role="navigation" aria-label="breadcrumbs navigation">
 
   <ul class="wy-breadcrumbs">
-    
+
       <li><a href="../index.html">Docs</a> &raquo;</li>
-        
+
           <li><a href="../operators.html">Operators</a> &raquo;</li>
-        
+
           <li><a href="aws.html">Amazon Web Services operators</a> &raquo;</li>
-        
+
       <li>redshift&gt;: Redshift operations</li>
-    
-    
+
+
       <li class="wy-breadcrumbs-aside">
-        
-            
+
+
             <a href="../_sources/operators/redshift.md.txt" rel="nofollow"> View page source</a>
-          
-        
+
+
       </li>
-    
+
   </ul>
 
-  
+
   <hr/>
 </div>
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
            <div itemprop="articleBody">
-            
+
   <div class="section" id="redshift-redshift-operations">
 <h1>redshift&gt;: Redshift operations<a class="headerlink" href="#redshift-redshift-operations" title="Permalink to this headline">¶</a></h1>
 <p><strong>redshift&gt;</strong> operator runs queries and/or DDLs on Redshift.</p>
@@ -368,25 +368,32 @@ If the query that created the status table completed 24 hours ago, this operator
 </pre></div>
 </div>
 </li>
+<li><p><strong>status_table_cleanup</strong>: TIME VALUES</p>
+<p>The period of time to clean up the status_table. The status_table will be created with "strict_transaction: true" (default). status_table will be deleted when the status_table_cleanup period expires and the redshift operator is executed.<em>Default</em>: <code class="docutils literal notranslate"><span class="pre">24h</span></code>(24 hours).</p>
+<p>Examples:</p>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="n">status_table_cleanup</span><span class="p">:</span> <span class="mi">5</span><span class="n">s</span>
+</pre></div>
+</div>
+</li>
 </ul>
 </div>
 </div>
 
 
            </div>
-           
+
           </div>
           <footer>
-  
+
     <div class="rst-footer-buttons" role="navigation" aria-label="footer navigation">
-      
+
         <a href="redshift_load.html" class="btn btn-neutral float-right" title="redshift_load&gt;: Redshift load operations" accesskey="n" rel="next">Next <span class="fa fa-arrow-circle-right"></span></a>
-      
-      
+
+
         <a href="s3_wait.html" class="btn btn-neutral float-left" title="s3_wait&gt;: Wait for a file in Amazon S3" accesskey="p" rel="prev"><span class="fa fa-arrow-circle-left"></span> Previous</a>
-      
+
     </div>
-  
+
 
   <hr/>
 
@@ -400,7 +407,7 @@ If the query that created the status table completed 24 hours ago, this operator
     <br/>
     <br/>
     <p><a href="https://digdag.io/">Digdag</a> is an open source project, invented and sponsored by <a href="https://www.treasuredata.com/">Treasure Data, Inc.</a> under the Apache 2.0 Licence.</p>
-     
+
 
 
 </footer>
@@ -411,7 +418,7 @@ If the query that created the status table completed 24 hours ago, this operator
     </section>
 
   </div>
-  
+
 
 
   <script type="text/javascript">
@@ -420,10 +427,10 @@ If the query that created the status table completed 24 hours ago, this operator
       });
   </script>
 
-  
-  
-    
-   
+
+
+
+
 
 </body>
 </html>


### PR DESCRIPTION
The status_table_cleanup option was not mentioned in the redshift operator options, so I added it.
By default, the status_table is created on every execution, but it may be mistakenly assumed that it is not deleted.