### PR TITLE
Add a description for poling cycle

### DIFF
--- a/operators/s3_wait.html
+++ b/operators/s3_wait.html
@@ -307,7 +307,7 @@ s3.last_object is empty in this case. Empty check is required in following tasks
 </div>
 </li>
 </ul>
-<p>Note: The <strong>s3_wait&gt;</strong> operator makes use of polling with <em>exponential backoff</em>. As such there might be some time interval between a file being created and the <strong>s3_wait&gt;</strong> operator detecting it.</p>
+<p>Note: The <strong>s3_wait&gt;</strong> operator makes use of polling with <em>exponential backoff</em>. As such there might be some time interval between a file being created and the <strong>s3_wait&gt;</strong> operator detecting it.</p><p>This interval starts at 5 seconds and increases to double each cycle, with a maximum interval of 5 minutes.</p>
 </div>
 </div>
 


### PR DESCRIPTION
Current [document](https://docs.digdag.io/operators/s3_wait.html) doesn't mention `s3_wait` poling cycle, so added cycle to Note section.

See: https://github.com/treasure-data/digdag/blob/42ea7cb71270957ea6424c2df88dd7c65d248789/digdag-standards/src/main/java/io/digdag/standards/operator/aws/S3WaitOperatorFactory.java#L47